### PR TITLE
Add missing poolId to XSG pool configs (#85)

### DIFF
--- a/pool_configs/examples/xsg.json
+++ b/pool_configs/examples/xsg.json
@@ -56,6 +56,9 @@
             }
         }
     },
+    
+    "poolId": "main",
+    "_comment_poolId": "use it for region identification: eu, us, asia or keep default if you have one stratum instance for one coin",
 
     "daemons": [
         {


### PR DESCRIPTION
If you have multiple stratums, not having this config can lead to someone putting one rig on each stratum to earn **much** more than they should.